### PR TITLE
chore(shorebird_cli): add the concept of an extension command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 # Cached files
 bin/cache/
+
+# IDE files
+.idea/

--- a/packages/shorebird_cli/lib/src/command_runner.dart
+++ b/packages/shorebird_cli/lib/src/command_runner.dart
@@ -80,6 +80,7 @@ class ShorebirdCliCommandRunner extends CompletionCommandRunner<int> {
   @override
   Future<int> run(Iterable<String> args) async {
     try {
+      await preprocess(args);
       final topLevelResults = parse(args);
 
       // Set up our context before running the command.

--- a/packages/shorebird_cli/lib/src/commands/commands.dart
+++ b/packages/shorebird_cli/lib/src/commands/commands.dart
@@ -4,6 +4,7 @@ export 'build/build_command.dart';
 export 'cache/cache.dart';
 export 'collaborators/collaborators.dart';
 export 'doctor_command.dart';
+export 'extension_command.dart';
 export 'flutter/flutter.dart';
 export 'init_command.dart';
 export 'login_ci_command.dart';

--- a/packages/shorebird_cli/lib/src/commands/extension_command.dart
+++ b/packages/shorebird_cli/lib/src/commands/extension_command.dart
@@ -1,0 +1,72 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:args/command_runner.dart';
+import 'package:shorebird_cli/src/command.dart';
+import 'package:shorebird_cli/src/logger.dart';
+import 'package:shorebird_cli/src/process.dart';
+
+class ExtensionCommand extends ShorebirdCommand {
+  ExtensionCommand(this.extensionName);
+
+  final String extensionName;
+
+  @override
+  String get description => 'A Shorebird extension command for $extensionName';
+
+  @override
+  String get name => extensionName;
+
+  static String executableName(String extensionName) {
+    return 'shorebird-$extensionName';
+  }
+
+  static Future<bool> canExecute(String extensionName) async {
+    try {
+      final executableName = ExtensionCommand.executableName(extensionName);
+      final processResult = await process.run(executableName, List.empty());
+      return processResult.exitCode == 0;
+    } catch (e) {
+      return false;
+    }
+  }
+
+  @override
+  FutureOr<int> run() async {
+    final arguments = results.arguments;
+    final executableName = ExtensionCommand.executableName(extensionName);
+    final runningProcess = await process.start(executableName, arguments);
+
+    Future<void> outStream(p) async {
+      await runningProcess.stdout.transform(utf8.decoder).forEach(logger.info);
+    }
+
+    Future<void> errStream(p) async {
+      await runningProcess.stderr.transform(utf8.decoder).forEach(logger.err);
+    }
+
+    await Future.wait([outStream(process), errStream(process)]);
+    return runningProcess.exitCode;
+  }
+}
+
+extension ShorebirdExtensionsCommandRunner on CommandRunner<int> {
+  Future<void> preprocess(Iterable<String> args) async {
+    for (final arg in args) {
+      if (arg.startsWith(RegExp('[-]+'))) {
+        continue;
+      }
+
+      final possibleExtension = !commands.containsKey(arg);
+      if (possibleExtension) {
+        final commandName = arg;
+        final canExecuteExtension =
+            await ExtensionCommand.canExecute(commandName);
+        if (canExecuteExtension) {
+          addCommand(ExtensionCommand(commandName));
+        }
+      }
+      break;
+    }
+  }
+}

--- a/packages/shorebird_cli/lib/src/process.dart
+++ b/packages/shorebird_cli/lib/src/process.dart
@@ -41,7 +41,7 @@ class ShorebirdProcess {
     Logger? logger,
     ProcessWrapper? processWrapper, // For mocking ShorebirdProcess.
   })  : logger = logger ?? Logger(),
-        processWrapper = processWrapper ?? ProcessWrapper();
+        processWrapper = processWrapper ?? const ProcessWrapper();
 
   final ProcessWrapper processWrapper;
   final EngineConfig engineConfig;
@@ -157,6 +157,8 @@ class ShorebirdProcessResult {
 // coverage:ignore-start
 @visibleForTesting
 class ProcessWrapper {
+  const ProcessWrapper();
+
   Future<ShorebirdProcessResult> run(
     String executable,
     List<String> arguments, {

--- a/packages/shorebird_cli/test/fixtures/extensions/shorebird-extension
+++ b/packages/shorebird_cli/test/fixtures/extensions/shorebird-extension
@@ -1,0 +1,3 @@
+#! /usr/bin/env bash
+
+echo "This is a Shorebird extension usage statement"

--- a/packages/shorebird_cli/test/src/commands/extension_command_test.dart
+++ b/packages/shorebird_cli/test/src/commands/extension_command_test.dart
@@ -1,0 +1,233 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:args/args.dart';
+import 'package:args/command_runner.dart';
+import 'package:mason_logger/mason_logger.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:path/path.dart' as p;
+import 'package:scoped/scoped.dart';
+import 'package:shorebird_cli/src/command_runner.dart';
+import 'package:shorebird_cli/src/commands/extension_command.dart';
+import 'package:shorebird_cli/src/logger.dart';
+import 'package:shorebird_cli/src/process.dart';
+
+import 'package:test/test.dart';
+
+class _MockArgResults extends Mock implements ArgResults {}
+
+class _MockLogger extends Mock implements Logger {}
+
+class _MockProgress extends Mock implements Progress {}
+
+class _MockProcess extends Mock implements Process {}
+
+class _MockShorebirdProcess extends Mock implements ShorebirdProcess {}
+
+class _MockShorebirdProcessResult extends Mock
+    implements ShorebirdProcessResult {}
+
+class _MockIOSink extends Mock implements IOSink {}
+
+void main() {
+  late ArgResults argResults;
+  late Logger logger;
+  late Process process;
+  late ShorebirdProcess shorebirdProcess;
+  late ShorebirdProcessResult shorebirdProcessResult;
+  late IOSink ioSink;
+  late ShorebirdCliCommandRunner commandRunner;
+  late ExtensionCommand command;
+  late String commandOutput;
+
+  Map<String, Command<int>> getExtensionCommands() {
+    final extensionCommands = <String, ExtensionCommand>{};
+    commandRunner.commands.forEach((key, value) {
+      if (value is ExtensionCommand) {
+        extensionCommands[key] = value;
+      }
+    });
+    return extensionCommands;
+  }
+
+  bool hasExtensionCommands() {
+    return getExtensionCommands().isNotEmpty;
+  }
+
+  R runWithOverrides<R>(R Function() body) {
+    return runScoped(
+      body,
+      values: {
+        loggerRef.overrideWith(() => logger),
+        processRef.overrideWith(() => shorebirdProcess)
+      },
+    );
+  }
+
+  setUpAll(() {
+    registerFallbackValue(const Stream<List<int>>.empty());
+  });
+
+  setUp(() {
+    argResults = _MockArgResults();
+    logger = _MockLogger();
+    process = _MockProcess();
+    shorebirdProcess = _MockShorebirdProcess();
+    shorebirdProcessResult = _MockShorebirdProcessResult();
+
+    commandOutput =
+        File(p.join('test', 'fixtures', 'extensions', 'shorebird-extension'))
+            .readAsStringSync();
+    ioSink = _MockIOSink();
+
+    when(
+      () => shorebirdProcess.start(
+        any(),
+        any(),
+        runInShell: any(named: 'runInShell'),
+      ),
+    ).thenAnswer((_) async => process);
+
+    when(
+      () => shorebirdProcess.run(
+        any(),
+        any(),
+        runInShell: any(named: 'runInShell'),
+      ),
+    ).thenAnswer((_) async => shorebirdProcessResult);
+
+    when(() => argResults.arguments).thenReturn(List<String>.empty());
+    when(() => argResults.rest).thenReturn([]);
+    when(() => logger.progress(any())).thenReturn(_MockProgress());
+    when(() => ioSink.addStream(any())).thenAnswer((_) async {});
+
+    commandRunner = runWithOverrides(ShorebirdCliCommandRunner.new);
+    command = runWithOverrides(() => ExtensionCommand('extension'))
+      ..testArgResults = argResults;
+  });
+
+  test('has a description', () {
+    expect(command.description, isNotEmpty);
+  });
+
+  group('validate extensions to CommandRunner', () {
+    test(
+        'command runner with no options or arguments will not have any '
+        'extension commands', () async {
+      final args = List<String>.empty();
+      await runWithOverrides(() => commandRunner.preprocess(args));
+      expect(hasExtensionCommands(), false);
+    });
+
+    test('command runner with all options will not have any extension commands',
+        () async {
+      const args = ['--option1', '--option2', '--option3'];
+      await runWithOverrides(() => commandRunner.preprocess(args));
+      expect(hasExtensionCommands(), false);
+    });
+
+    test(
+        'command runner with options and a known command will not have an '
+        'extension command', () async {
+      const args = ['--option1', '--option2', '--option3', 'doctor'];
+      await runWithOverrides(() => commandRunner.preprocess(args));
+
+      expect(hasExtensionCommands(), false);
+    });
+
+    test(
+        'command runner with a known command and options will not have an '
+        'extension command', () async {
+      const args = ['doctor', '--option1', '---option2', '--option3'];
+      await runWithOverrides(() => commandRunner.preprocess(args));
+      expect(hasExtensionCommands(), false);
+    });
+
+    test(
+        'command runner with an unknown command that is executable will have an'
+        ' extension command', () async {
+      const commandName = 'myunknowncommand';
+      const args = [commandName];
+      when(
+        () => shorebirdProcessResult.exitCode,
+      ).thenReturn(ExitCode.success.code);
+
+      await runWithOverrides(() => commandRunner.preprocess(args));
+
+      final extensionCommands = getExtensionCommands();
+
+      expect(extensionCommands.length, 1);
+      expect(extensionCommands.containsKey(commandName), true);
+    });
+
+    test(
+        'command runner with an unknown command that is not executable will '
+        'not have an extension command', () async {
+      const commandName = 'myunknowncommand';
+      const args = [commandName];
+      when(
+        () => shorebirdProcessResult.exitCode,
+      ).thenReturn(ExitCode.software.code);
+
+      await runWithOverrides(() => commandRunner.preprocess(args));
+
+      final extensionCommands = getExtensionCommands();
+
+      expect(extensionCommands.length, 0);
+      expect(extensionCommands.containsKey(commandName), false);
+    });
+
+    test(
+        'command runner with an unknown command that throws an exception '
+        'on execution will not have an extension command', () async {
+      const commandName = 'myunknowncommand';
+      const args = [commandName];
+      when(() => shorebirdProcess.run(any(), any())).thenThrow(Exception());
+
+      await runWithOverrides(() => commandRunner.preprocess(args));
+
+      final extensionCommands = getExtensionCommands();
+
+      expect(extensionCommands.length, 0);
+      expect(extensionCommands.containsKey(commandName), false);
+    });
+  });
+
+  group('validate an extension command can be executed', () {
+    test(
+        'command runner with an known command that is executable completes'
+        ' succesfully', () async {
+      when(
+        () => shorebirdProcessResult.exitCode,
+      ).thenReturn(ExitCode.success.code);
+
+      when(
+        () => process.stdout,
+      ).thenAnswer((_) => Stream.value(utf8.encode(commandOutput)));
+      when(() => process.stdin).thenAnswer((_) => ioSink);
+      when(() => process.stderr).thenAnswer((_) => const Stream.empty());
+      when(() => process.exitCode).thenAnswer((_) async => exitCode);
+
+      when(
+        () => shorebirdProcess.start(
+          any(),
+          any(),
+        ),
+      ).thenAnswer((_) async => process);
+
+      await runWithOverrides(() => command.run());
+
+      verify(
+        () => shorebirdProcess.start(
+          'shorebird-extension',
+          [],
+        ),
+      ).called(1);
+
+      verify(
+        () => logger.info(any(that: contains(commandOutput))),
+      ).called(1);
+    });
+  });
+}


### PR DESCRIPTION
An extension command follows the Git model of CLI extension where any command unknown to the git CLI that matches the pattern git-<command> and is executable can be used to extend the Git command set.

For example:

git lfs

If the 'lfs' command is not implemented within Git's internal commands then the Git command line parser would check to see if 'git-lfs' exists and is executable.  If so, then the Git CLI passes execution to that script.

refactor(shorebird_cli): introduce ShorebirdExtension concept for encapsulation and testability

refactor(shorebird_cli): simplified closer to original implementation

<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

<!--- Describe your changes in detail -->

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
